### PR TITLE
25 timer cleanup

### DIFF
--- a/src/bboard/main.py
+++ b/src/bboard/main.py
@@ -10,7 +10,6 @@ usage:  $ fastapi dev src/bboard/main.py
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse, HTMLResponse
-from fontTools.merge import timer
 
 from bboard.demo.clock_display import clock_display, clock_reading, stop_watch
 from bboard.demo.greeting import greeting
@@ -38,10 +37,11 @@ patch_requests_module()
 async def hello() -> dict[str, str]:
     # We keep main.py small, delegating most endpoint logic to companion modules.
     # Please follow this pattern when adding new endpoints.
+    # Function name in main.py should match the endpoint name.
     return dict(greeting())
 
 
-@app.get("/demo/stop_watch")
+@app.get("/demo/timer")
 async def timer() -> HTMLResponse:
     """Simple timer displayed in seconds"""
     return HTMLResponse(content=stop_watch())

--- a/tests/clock_display_test.py
+++ b/tests/clock_display_test.py
@@ -1,9 +1,12 @@
 import unittest
 
-from bboard.demo.clock_display import clock_display, clock_reading
+from bboard.demo.clock_display import clock_display, clock_reading, stop_watch
 
 
 class ClockDisplayTest(unittest.TestCase):
     def test_clock_display(self) -> None:
         self.assertGreaterEqual(len(clock_display()), 587)
         self.assertGreaterEqual(len(clock_reading()), 39)
+
+    def test_stop_watch(self) -> None:
+        self.assertGreaterEqual(len(stop_watch()), 1350)


### PR DESCRIPTION
Now it lints clean, and `$ make test` reports 100% code coverage.

## Summary by Sourcery

Clean up the timer functionality by adding a test for the stop_watch function and renaming the endpoint to /demo/timer for improved clarity. Ensure the codebase is lint-free and achieves 100% test coverage.

New Features:
- Add a new test for the stop_watch function in the ClockDisplayTest class.

Enhancements:
- Rename the endpoint from /demo/stop_watch to /demo/timer for better clarity and consistency.

Tests:
- Introduce a test case for the stop_watch function to ensure its output length is at least 1350.