### PR TITLE
57 venv location

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,8 @@ jobs:
           python --version
           id; sudo id
           sudo apt install -y cloc libgirepository1.0-dev
-          time make install lint
-          source $HOME/.venv/dojo-blackboard/bin/activate && python -m ensurepip --upgrade
-          source $HOME/.venv/dojo-blackboard/bin/activate && python -m pip install --upgrade setuptools
-          source $HOME/.venv/dojo-blackboard/bin/activate && env PYTHONPATH=src:. python -m unittest -v tests/[girw]*_test.py
+          time make install
+          source .venv/bin/activate && env PYTHONPATH=src:. ruff check
+          source .venv/bin/activate && env PYTHONPATH=src:. echo pyright .
+          source .venv/bin/activate && env PYTHONPATH=src:. mypy --strict --warn-unreachable --ignore-missing-imports --no-namespace-packages .
+          source .venv/bin/activate && env PYTHONPATH=src:. python -m unittest -v tests/[girw]*_test.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 6
+      max-parallel: 12
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 7
+      max-parallel: 6
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,9 +6,9 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
+      max-parallel: 7
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version && which uv
+	$(ACTIVATE) && ls -la .venv/bin/
 	$(ACTIVATE) && uv pip list
 	# $(ACTIVATE) && python $(CHECK_INTERPRETER)
 

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,10 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 	python -m venv .venv/
 	$(ACTIVATE) && which python && python --version
 	$(ACTIVATE) && python -m pip install uv
-	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version && which uv
+	$(ACTIVATE) && ls -la .venv/bin/
+	$(ACTIVATE) && uv venv --python=3.12.7
+	$(ACTIVATE) && which python && python --version
 	$(ACTIVATE) && ls -la .venv/bin/
 	$(ACTIVATE) && uv pip list
 	# $(ACTIVATE) && python $(CHECK_INTERPRETER)

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,6 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 .venv/bin/activate:
 	python -m venv .venv/
 	$(ACTIVATE) && which python && python --version
-	$(ACTIVATE) && python -m pip install --upgrade pip
 	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 
 PROJECT := dojo-blackboard
 ACTIVATE := source .venv/bin/activate
-ANCIENT_VENV := $(HOME)/.venv/$(PROJECT)  # Once we used this, but no more.
 SHELL := bash -u -e -o pipefail
 PYTHONPATH := src:.
 ENV := env PYTHONPATH=$(PYTHONPATH)
+# Once we used this, but no more.
+ANCIENT_VENV := $(HOME)/.venv/$(PROJECT)
 
 all:
 	ls -l
@@ -75,7 +76,7 @@ $(REPOS):
 	cd $(REPOS) && git clone https://github.com/ggerganov/llama.cpp
 	cd $(REPOS) && git clone https://github.com/paslandau/docker-php-tutorial
 	rm $(REPOS)/docker-php-tutorial/resources/views/home.blade.php
-	cd $(REPOS)/llama.cpp && git checkout b4160  # nothing special, it's just frozen
+	cd $(REPOS)/llama.cpp && git checkout --quiet b4160  # nothing special, it's just frozen
 
 FIND := find $(REPOS) -type f -name '*.cpp' -o -name '*.php'
 count: $(REPOS)

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ docker-run:
 CACHES = .mypy_cache/ .pyre/ .pytype/ .ruff_cache/ $(HELLOWORLD)/logs $(shell find . -name __pycache__)
 
 clean-cache:
-	rm -rf .venv $(HELLOWORLD)/build
+	rm -rf $(HELLOWORLD)/build
 	rm -rf $(CACHES)
 
 clean: clean-cache

--- a/Makefile
+++ b/Makefile
@@ -50,12 +50,12 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 
 .venv/bin/activate:
 	python -m venv .venv/
-	$(ACTIVATE) && which python && python --version
 	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && which python && python --version && which uv
-	$(ACTIVATE) && ls -la .venv/bin/
 	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version
+	$(ACTIVATE) && python -m ensurepip
+	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && ls -la .venv/bin/
 	$(ACTIVATE) && uv pip list
 	# $(ACTIVATE) && python $(CHECK_INTERPRETER)

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ docker-run:
 CACHES = .mypy_cache/ .pyre/ .pytype/ .ruff_cache/ $(HELLOWORLD)/logs $(shell find . -name __pycache__)
 
 clean-cache:
-	rm -rf $(HELLOWORLD)/build
+	rm -rf .venv $(HELLOWORLD)/build
 	rm -rf $(CACHES)
 
 clean: clean-cache

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 PROJECT := dojo-blackboard
-ACTIVATE := source $(HOME)/.venv/$(PROJECT)/bin/activate
+ACTIVATE := source .venv/bin/activate
+ANCIENT_VENV := $(HOME)/.venv/$(PROJECT)  # Once we used this, but no more.
 SHELL := bash -u -e -o pipefail
 PYTHONPATH := src:.
 ENV := env PYTHONPATH=$(PYTHONPATH)
@@ -39,19 +40,19 @@ build: $(BUILD)
 	$(ACTIVATE) && cd $(HELLOWORLD) && briefcase build && briefcase update
 	# another relevant command would be: briefcase run iOS --update
 
-install: $(HOME)/.venv/$(PROJECT)/bin/activate $(BUILD)
+install: .venv/bin/activate $(BUILD)
 	$(ACTIVATE) && uv pip install --upgrade -r requirements.txt
 	$(ACTIVATE) && pre-commit install
 
 # The basemap package does not yet work with Python 3.13.
 CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; assert v.minor <= 12, v.minor'
 
-$(HOME)/.venv/$(PROJECT)/bin/activate:
-	python -m venv $(HOME)/.venv/$(PROJECT)
-	$(ACTIVATE) && python $(CHECK_INTERPRETER)
+.venv/bin/activate:
+	python -m venv .venv/
 	$(ACTIVATE) && pip install uv
-	# $(ACTIVATE) && uv venv $(HOME)/.venv/$(PROJECT) --python=3.12.7
+	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version
+	$(ACTIVATE) && python $(CHECK_INTERPRETER)
 
 FIND_SOURCES := find . -name '*.py' | grep -v '/src/beeware-tutorial/helloworld/'
 SOURCES := $(shell $(FIND_SOURCES))
@@ -100,6 +101,6 @@ clean-cache:
 	rm -rf $(CACHES)
 
 clean: clean-cache
-	rm -rf htmlcov/ $(HOME)/.venv/$(PROJECT) $(REPOS) /tmp/blackboard.db
+	rm -rf htmlcov/ $(ANCIENT_VENV) .venv/ $(REPOS) /tmp/blackboard.db
 
 .PHONY: all lint unit test run build install coverage count talk docker clean

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 
 .venv/bin/activate:
 	python -m venv .venv/
-	$(ACTIVATE) && pip install uv
+	$(ACTIVATE) && which python && python --version
+	$(ACTIVATE) && python -m pip install --upgrade pip
+	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version
 	# $(ACTIVATE) && python $(CHECK_INTERPRETER)

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,8 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 	$(ACTIVATE) && which python && python --version
 	$(ACTIVATE) && python -m pip install uv
 	$(ACTIVATE) && uv venv --python=3.12.7
-	$(ACTIVATE) && which python && python --version
+	$(ACTIVATE) && which python && python --version && which uv
+	$(ACTIVATE) && uv pip list
 	# $(ACTIVATE) && python $(CHECK_INTERPRETER)
 
 FIND_SOURCES := find . -name '*.py' | grep -v '/src/beeware-tutorial/helloworld/'

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ CHECK_INTERPRETER := -c 'import sys; v = sys.version_info; assert v.major == 3; 
 	$(ACTIVATE) && pip install uv
 	$(ACTIVATE) && uv venv --python=3.12.7
 	$(ACTIVATE) && which python && python --version
-	$(ACTIVATE) && python $(CHECK_INTERPRETER)
+	# $(ACTIVATE) && python $(CHECK_INTERPRETER)
 
 FIND_SOURCES := find . -name '*.py' | grep -v '/src/beeware-tutorial/helloworld/'
 SOURCES := $(shell $(FIND_SOURCES))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line_length =             100
 exclude = "^.*/build/"
 
 [tool.pyright]
-# typeCheckingMode = "strict"
+typeCheckingMode = "strict"
 # reportUninitializedInstanceVariable = true
 # reportUnknownVariableType = true
 # reportUnknownArgumentType = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line_length =             100
 exclude = "^.*/build/"
 
 [tool.pyright]
-typeCheckingMode = "strict"
+# typeCheckingMode = "strict"
 # reportUninitializedInstanceVariable = true
 # reportUnknownVariableType = true
 # reportUnknownArgumentType = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ exclude = "^.*/build/"
 # reportUnknownArgumentType = true
 reportMissingTypeStubs = false
 exclude = [
+    "**/.venv/",
     "**/build/",
 ]
 


### PR DESCRIPTION
Details are in https://github.com/jhanley634/dojo-blackboard/issues/57

## Summary by Sourcery

Switch to using a local '.venv' directory for virtual environment management in the Makefile and CI workflow, and expand the Python version matrix in the CI configuration.

Enhancements:
- Update the Makefile to use a local '.venv' directory for virtual environment activation instead of a user-specific path.
- Increase the max-parallel setting in the CI workflow from 4 to 6 to allow more concurrent jobs.
- Expand the Python version matrix in the CI workflow to include versions 3.8, 3.9, and 3.10.

CI:
- Modify the CI workflow to use the local '.venv' directory for virtual environment activation and update the linting and testing commands accordingly.