### PR TITLE
Check if API key is enabled

### DIFF
--- a/tests/vehicles_test.py
+++ b/tests/vehicles_test.py
@@ -62,5 +62,6 @@ class VehiclesTest(unittest.TestCase):
 
     @staticmethod
     def test_store_vehicle_journeys() -> None:
-        with suppress(IntegrityError):
-            store_vehicle_journeys("SC")
+        if is_enabled(KEY_NAME):
+            with suppress(IntegrityError):
+                store_vehicle_journeys("SC")


### PR DESCRIPTION
## Summary by Sourcery

Add a check to verify if the API key is enabled before executing the store_vehicle_journeys function, and update the corresponding test to reflect this change.

Bug Fixes:
- Add a check to ensure the API key is enabled before storing vehicle journeys.

Tests:
- Update the test for storing vehicle journeys to include a check for API key enablement.