### PR TITLE
77 hashable

### DIFF
--- a/src/custom_dict/counting_dict.py
+++ b/src/custom_dict/counting_dict.py
@@ -1,5 +1,5 @@
 from collections import Counter, UserDict
-from collections.abc import Generator
+from collections.abc import Generator, Hashable
 from copy import deepcopy
 from typing import Any, Self
 
@@ -9,11 +9,11 @@ class AccessCounterDict(UserDict[Any, Any]):
     # NB: This class extends a different class, rather than dict.
 
     def __init__(
-        self, initial_data: dict[Any, Any] | None = None, /, **kwargs: dict[Any, Any]
+        self, initial_data: dict[Hashable, Any] | None = None, /, **kwargs: dict[Any, Any]
     ) -> None:
-        d: dict[Any, Any] = initial_data or {}
+        d: dict[Hashable, Any] = initial_data or {}
         super().__init__(d, **kwargs)
-        self.count: Counter[Any] = Counter()  # per-key access counts
+        self.count: Counter[Hashable] = Counter()  # per-key access counts
 
     def copy(self) -> "AccessCounterDict":
         c = AccessCounterDict()
@@ -21,7 +21,7 @@ class AccessCounterDict(UserDict[Any, Any]):
         c.reset_counts()
         return c
 
-    def __deepcopy__(self, _memo: dict[Any, Any]) -> "AccessCounterDict":
+    def __deepcopy__(self, _memo: dict[Hashable, Any]) -> "AccessCounterDict":
         c = AccessCounterDict()
         c.count = deepcopy(self.count)
         for k, v in self.items():
@@ -32,17 +32,17 @@ class AccessCounterDict(UserDict[Any, Any]):
         self.count.clear()
         return self
 
-    def get_count(self, key: Any) -> int:
+    def get_count(self, key: Hashable) -> int:
         return self.count[key]
 
-    def __delitem__(self, key: Any) -> None:
+    def __delitem__(self, key: Hashable) -> None:
         del self.count[key]
         return super().__delitem__(key)
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Hashable) -> Any:
         self.count[key] += 1
         return super().__getitem__(key)
 
-    def unread_keys(self) -> Generator[Any]:
+    def unread_keys(self) -> Generator[Hashable]:
         """Generates keys that were stored, are still valid, and have not been read."""
         return (k for k in self if self.count[k] == 0)

--- a/src/custom_dict/counting_dict.py
+++ b/src/custom_dict/counting_dict.py
@@ -21,7 +21,7 @@ class AccessCounterDict(UserDict[Any, Any]):
         c.reset_counts()
         return c
 
-    def __deepcopy__(self, _memo: dict[Hashable, Any]) -> "AccessCounterDict":
+    def __deepcopy__(self, _memo: dict[int, Any]) -> "AccessCounterDict":
         c = AccessCounterDict()
         c.count = deepcopy(self.count)
         for k, v in self.items():

--- a/src/custom_dict/counting_dict_test.py
+++ b/src/custom_dict/counting_dict_test.py
@@ -2,7 +2,7 @@ import unittest
 from copy import deepcopy
 
 from custom_dict.counting_dict import AccessCounterDict
-from custom_dict.tracking_dict_test import _example_mapping
+from custom_dict.tracking_dict_test import _example_mapping, unread_keys
 
 
 class AccessCounterDictTest(unittest.TestCase):
@@ -44,12 +44,12 @@ class AccessCounterDictTest(unittest.TestCase):
         d.update({"b": 12, "x": 13, "y": 14, "z": 15})
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", "".join(d.unread_keys()))
+        self.assertEqual("abdxz", unread_keys(d))
 
     def test_deepcopy(self) -> None:
         d1 = self.d.copy()
         d = deepcopy(d1)
-        self.assertEqual("", "".join(d1.unread_keys()))
+        self.assertEqual("", unread_keys(d1))
 
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", "".join(d.unread_keys()))
+        self.assertEqual("abd", unread_keys(d))

--- a/src/custom_dict/counting_dict_test.py
+++ b/src/custom_dict/counting_dict_test.py
@@ -44,7 +44,7 @@ class AccessCounterDictTest(unittest.TestCase):
         d.update({"b": 12, "x": 13, "y": 14, "z": 15})
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", unread_keys(d))
+        self.assertEqual("a b d x z", unread_keys(d))
 
     def test_deepcopy(self) -> None:
         d1 = self.d.copy()
@@ -52,4 +52,4 @@ class AccessCounterDictTest(unittest.TestCase):
         self.assertEqual("", unread_keys(d1))
 
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", unread_keys(d))
+        self.assertEqual("a b d", unread_keys(d))

--- a/src/custom_dict/counting_dict_test.py
+++ b/src/custom_dict/counting_dict_test.py
@@ -2,12 +2,12 @@ import unittest
 from copy import deepcopy
 
 from custom_dict.counting_dict import AccessCounterDict
-from custom_dict.tracking_dict_test import _example_mapping, unread_keys
+from custom_dict.tracking_dict_test import example_mapping, unread_keys
 
 
 class AccessCounterDictTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.d = AccessCounterDict(dict(_example_mapping()))
+        self.d = AccessCounterDict(dict(example_mapping()))
 
     def test_access_counter_dict(self) -> None:
         d = self.d.copy()

--- a/src/custom_dict/tracking_dict.py
+++ b/src/custom_dict/tracking_dict.py
@@ -34,7 +34,7 @@ class TrackingDict(UserDict[Any, Any]):
         c.update(self)
         return c
 
-    def __deepcopy__(self, _memo: dict[Hashable, Any]) -> "TrackingDict":
+    def __deepcopy__(self, _memo: dict[int, Any]) -> "TrackingDict":
         c = TrackingDict()
         c.used = deepcopy(self.used)
         for k, v in self.items():

--- a/src/custom_dict/tracking_dict.py
+++ b/src/custom_dict/tracking_dict.py
@@ -1,5 +1,5 @@
 from collections import UserDict
-from collections.abc import Generator
+from collections.abc import Generator, Hashable
 from copy import deepcopy
 from typing import Any
 
@@ -23,33 +23,33 @@ class TrackingDict(UserDict[Any, Any]):
     """
 
     def __init__(
-        self, initial_data: dict[Any, Any] | None = None, /, **kwargs: dict[Any, Any]
+        self, initial_data: dict[Hashable, Any] | None = None, /, **kwargs: dict[Any, Any]
     ) -> None:
-        d: dict[Any, Any] = initial_data or {}
+        d: dict[Hashable, Any] = initial_data or {}
         super().__init__(d, **kwargs)
-        self.used: set[Any] = set()  # keys the app has read / consumed
+        self.used: set[Hashable] = set()  # keys the app has read / consumed
 
     def copy(self) -> "TrackingDict":
         c = TrackingDict()
         c.update(self)
         return c
 
-    def __deepcopy__(self, _memo: dict[Any, Any]) -> "TrackingDict":
+    def __deepcopy__(self, _memo: dict[Hashable, Any]) -> "TrackingDict":
         c = TrackingDict()
         c.used = deepcopy(self.used)
         for k, v in self.items():
             c[k] = deepcopy(v)
         return c
 
-    def __delitem__(self, key: Any) -> None:
+    def __delitem__(self, key: Hashable) -> None:
         self.used.discard(key)
         return super().__delitem__(key)
 
-    def __getitem__(self, key: Any) -> Any:
+    def __getitem__(self, key: Hashable) -> Any:
         self.used.add(key)
         return super().__getitem__(key)
 
-    def unread_keys(self) -> Generator[Any]:
+    def unread_keys(self) -> Generator[Hashable]:
         """Generates keys that were stored, are still valid, and have not been read."""
         for k in self.keys():
             if k not in self.used:

--- a/src/custom_dict/tracking_dict_test.py
+++ b/src/custom_dict/tracking_dict_test.py
@@ -13,7 +13,12 @@ def example_mapping() -> TrackingDict:
 
 
 def unread_keys(d: TrackingDict | AccessCounterDict) -> str:
-    return "".join(map(str, d.unread_keys()))
+    """
+    Returns blank delimited unread keys.
+
+    The result will be ambiguous if your keys contain SPACE characters.
+    """
+    return " ".join(map(str, d.unread_keys()))
 
 
 class TrackingDictTest(unittest.TestCase):
@@ -31,7 +36,7 @@ class TrackingDictTest(unittest.TestCase):
         d["d"] = 4
         d["e"] = 6
         d["e"] = 5
-        self.assertEqual("de", unread_keys(d))
+        self.assertEqual("d e", unread_keys(d))
         del d["d"]
         self.assertEqual(5, d["e"])
         self.assertEqual([], list(d.unread_keys()))
@@ -39,7 +44,7 @@ class TrackingDictTest(unittest.TestCase):
     def test_items(self) -> None:
         d = self.d.copy()
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", unread_keys(d))
+        self.assertEqual("a b d", unread_keys(d))
 
         for i, (_k, _v) in enumerate(d.items()):
             if i >= 1:
@@ -51,7 +56,7 @@ class TrackingDictTest(unittest.TestCase):
         d.update({"b": 12, "x": 13, "y": 14, "z": 15})
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", unread_keys(d))
+        self.assertEqual("a b d x z", unread_keys(d))
 
     def test_union(self) -> None:
         """Same as test_update(), pretty much."""
@@ -59,13 +64,13 @@ class TrackingDictTest(unittest.TestCase):
         d = d1 | {"b": 12, "x": 13, "y": 14, "z": 15}
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", unread_keys(d))
+        self.assertEqual("a b d x z", unread_keys(d))
 
     def test_popitem(self) -> None:
         d = self.d.copy()
         self.assertEqual(("a", 1), d.popitem())
         self.assertEqual(("b", 2), d.popitem())
-        self.assertEqual("cd", unread_keys(d))
+        self.assertEqual("c d", unread_keys(d))
 
         self.assertEqual(3, d.pop("c"))
         self.assertEqual("d", unread_keys(d))
@@ -74,7 +79,7 @@ class TrackingDictTest(unittest.TestCase):
         d1 = self.d.copy()
         d = d1.copy()
         self.assertEqual("", unread_keys(d1))
-        self.assertEqual("abcd", unread_keys(d))
+        self.assertEqual("a b c d", unread_keys(d))
 
     def test_deepcopy(self) -> None:
         d1 = self.d.copy()
@@ -82,7 +87,7 @@ class TrackingDictTest(unittest.TestCase):
         self.assertEqual("", unread_keys(d1))
 
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", unread_keys(d))
+        self.assertEqual("a b d", unread_keys(d))
 
 
 class TrackingDictPickleTest(unittest.TestCase):

--- a/src/custom_dict/tracking_dict_test.py
+++ b/src/custom_dict/tracking_dict_test.py
@@ -8,7 +8,7 @@ from custom_dict.counting_dict import AccessCounterDict
 from custom_dict.tracking_dict import TrackingDict
 
 
-def _example_mapping() -> TrackingDict:
+def example_mapping() -> TrackingDict:
     return TrackingDict({"a": 1, "b": 2, "c": 3, "d": 4})
 
 
@@ -18,7 +18,7 @@ def unread_keys(d: TrackingDict | AccessCounterDict) -> str:
 
 class TrackingDictTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.d = _example_mapping()
+        self.d = example_mapping()
 
     def test_tracking_dict(self) -> None:
         d = TrackingDict()
@@ -87,7 +87,7 @@ class TrackingDictTest(unittest.TestCase):
 
 class TrackingDictPickleTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.d = _example_mapping()
+        self.d = example_mapping()
 
     def test_pickle_roundtrip_with_filesystem(self) -> None:
         d = self.d.copy()

--- a/src/custom_dict/tracking_dict_test.py
+++ b/src/custom_dict/tracking_dict_test.py
@@ -89,6 +89,11 @@ class TrackingDictTest(unittest.TestCase):
         self.assertEqual(3, d["c"])
         self.assertEqual("a b d", unread_keys(d))
 
+    def test_tuple_keys(self) -> None:
+        d = TrackingDict({(5, 57): "a", (5, 59): "b", (7, 59): "c"})
+        self.assertEqual("b", d[(5, 59)])
+        self.assertEqual("(5, 57) (7, 59)", unread_keys(d))
+
 
 class TrackingDictPickleTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/src/custom_dict/tracking_dict_test.py
+++ b/src/custom_dict/tracking_dict_test.py
@@ -4,11 +4,16 @@ import unittest
 from copy import deepcopy
 from pathlib import Path
 
+from custom_dict.counting_dict import AccessCounterDict
 from custom_dict.tracking_dict import TrackingDict
 
 
 def _example_mapping() -> TrackingDict:
     return TrackingDict({"a": 1, "b": 2, "c": 3, "d": 4})
+
+
+def unread_keys(d: TrackingDict | AccessCounterDict) -> str:
+    return "".join(map(str, d.unread_keys()))
 
 
 class TrackingDictTest(unittest.TestCase):
@@ -26,7 +31,7 @@ class TrackingDictTest(unittest.TestCase):
         d["d"] = 4
         d["e"] = 6
         d["e"] = 5
-        self.assertEqual("de", "".join(d.unread_keys()))
+        self.assertEqual("de", unread_keys(d))
         del d["d"]
         self.assertEqual(5, d["e"])
         self.assertEqual([], list(d.unread_keys()))
@@ -34,19 +39,19 @@ class TrackingDictTest(unittest.TestCase):
     def test_items(self) -> None:
         d = self.d.copy()
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", "".join(d.unread_keys()))
+        self.assertEqual("abd", unread_keys(d))
 
         for i, (_k, _v) in enumerate(d.items()):
             if i >= 1:
                 break
-        self.assertEqual(["d"], list(d.unread_keys()))
+        self.assertEqual("d", unread_keys(d))
 
     def test_update(self) -> None:
         d = self.d.copy()
         d.update({"b": 12, "x": 13, "y": 14, "z": 15})
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", "".join(d.unread_keys()))
+        self.assertEqual("abdxz", unread_keys(d))
 
     def test_union(self) -> None:
         """Same as test_update(), pretty much."""
@@ -54,30 +59,30 @@ class TrackingDictTest(unittest.TestCase):
         d = d1 | {"b": 12, "x": 13, "y": 14, "z": 15}
         del d["c"]
         del d["y"]
-        self.assertEqual("abdxz", "".join(d.unread_keys()))
+        self.assertEqual("abdxz", unread_keys(d))
 
     def test_popitem(self) -> None:
         d = self.d.copy()
         self.assertEqual(("a", 1), d.popitem())
         self.assertEqual(("b", 2), d.popitem())
-        self.assertEqual("cd", "".join(d.unread_keys()))
+        self.assertEqual("cd", unread_keys(d))
 
         self.assertEqual(3, d.pop("c"))
-        self.assertEqual("d", "".join(d.unread_keys()))
+        self.assertEqual("d", unread_keys(d))
 
     def test_copy(self) -> None:
         d1 = self.d.copy()
         d = d1.copy()
-        self.assertEqual("", "".join(d1.unread_keys()))
-        self.assertEqual("abcd", "".join(d.unread_keys()))
+        self.assertEqual("", unread_keys(d1))
+        self.assertEqual("abcd", unread_keys(d))
 
     def test_deepcopy(self) -> None:
         d1 = self.d.copy()
         d = deepcopy(d1)
-        self.assertEqual("", "".join(d1.unread_keys()))
+        self.assertEqual("", unread_keys(d1))
 
         self.assertEqual(3, d["c"])
-        self.assertEqual("abd", "".join(d.unread_keys()))
+        self.assertEqual("abd", unread_keys(d))
 
 
 class TrackingDictPickleTest(unittest.TestCase):


### PR DESCRIPTION
## Summary by Sourcery

Refine key type annotations to require Hashable keys in tracking and counting dictionaries and streamline tests with new helper functions

Enhancements:
- Use Hashable instead of Any for key type hints in TrackingDict and AccessCounterDict constructors, methods, and attributes
- Introduce shared example_mapping and unread_keys test helpers and refactor tests to use them for cleaner setup and key-joining