### PR TITLE
93 filter users

### DIFF
--- a/src/challenge/twitter/schema.py
+++ b/src/challenge/twitter/schema.py
@@ -11,7 +11,7 @@ Base = declarative_base()
 class User(Base):  # type: ignore
     __tablename__ = "user"
     id = Column(Integer, primary_key=True)
-    recent_post = Column(Integer)
+    recent_post = Column(Integer, nullable=False)
 
 
 class Tweet(Base):  # type: ignore

--- a/src/challenge/twitter/twitter_table.py
+++ b/src/challenge/twitter/twitter_table.py
@@ -32,7 +32,7 @@ def init(n_users: int = 500) -> None:
         sess.query(User).delete()
 
         for u in range(n_users):
-            sess.add(User(id=u))
+            sess.add(User(id=u, recent_post=0))
 
         sess.commit()
 

--- a/src/challenge/twitter/twitter_table_test.py
+++ b/src/challenge/twitter/twitter_table_test.py
@@ -53,7 +53,7 @@ class TwitterTableUnitTest(unittest.TestCase):
             sess.query(User).delete()
 
             alice: UserId = 0
-            user = User(id=alice)
+            user = User(id=alice, recent_post=0)
             sess.add(user)
             sess.commit()
             self.assertEqual([], get_news_feed(alice))
@@ -69,7 +69,7 @@ class TwitterTableUnitTest(unittest.TestCase):
             self.assertEqual([1], get_news_feed(alice))
 
             bob: UserId = 1
-            sess.add(User(id=bob))
+            sess.add(User(id=bob, recent_post=0))
             sess.commit()
             self.assertEqual([], get_news_feed(bob))
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce pruning of idle users in news feed by tracking users' most recent posts and optimizing feed queries based on this data.

New Features:
- Add recent_post column to User model
- Update post_tweet to record the new tweet ID in recent_post
- Implement optimized get_news_feed that filters idle followees using recent_post

Enhancements:
- Add index on user.recent_post and recreate existing indexes on tweet and follower tables
- Rename the original get_news_feed to simple_get_news_feed as a fallback